### PR TITLE
Update Flatpak Metainfo

### DIFF
--- a/ch.threema.threema-web-desktop.metainfo.xml
+++ b/ch.threema.threema-web-desktop.metainfo.xml
@@ -24,6 +24,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.2.18" date="2022-07-21"/>
+    <release version="1.2.13" date="2022-06-07"/>
+    <release version="1.2.7" date="2022-04-26"/>
+    <release version="1.2.5" date="2022-04-20"/>
+    <release version="1.2.0" date="2022-04-04"/>
     <release version="1.1.0" date="2021-12-15"/>
     <release version="1.0.3" date="2021-10-26"/>
   </releases>

--- a/ch.threema.threema-web-desktop.metainfo.xml
+++ b/ch.threema.threema-web-desktop.metainfo.xml
@@ -15,11 +15,11 @@
   </description>
   <screenshots>
     <screenshot>
-      <caption>The Threema for desktop main window.</caption>
+      <caption>The Threema for desktop main window</caption>
       <image type="source">https://raw.githubusercontent.com/threema-ch/threema-web-electron/develop/assets/threema-desktop-screenshot1.png</image>
     </screenshot>
     <screenshot>
-      <caption>The Threema for desktop main window.</caption>
+      <caption>The Threema for desktop main window</caption>
       <image type="source">https://raw.githubusercontent.com/threema-ch/threema-web-electron/develop/assets/threema-desktop-screenshot2.png</image>
     </screenshot>
   </screenshots>

--- a/tools/packaging/package-deb.js
+++ b/tools/packaging/package-deb.js
@@ -29,7 +29,7 @@ async function main() {
     icon: configs["linux-deb"][myArgs[0]]["icons"],
     arch: "amd64",
     homepage: "https://threema.ch",
-    categories: ["Social Media"],
+    categories: ["Network", "InstantMessaging", "Chat"],
     description: "Desktop client for Threema (requires the mobile app)",
     productDescription:
       "Threema for desktop is a wrapped version of Threema Web. A multi-device solution will become available at a later date.",


### PR DESCRIPTION
Hi,

as per #4 the package is properly on Flathub (and noted as unofficial as requested and discussed there).  This PR mostly concerns the metainfo file (patch 1 and 3), but also related issues such as patch 2 which fixes the generation of .desktop files which do not contain the category "Social Media" so I replaced them with "Network", "InstantMessaging" and "Chat".