### PR TITLE
Add Release Notes to Appstream Metadata

### DIFF
--- a/ch.threema.threema-web-desktop.metainfo.xml
+++ b/ch.threema.threema-web-desktop.metainfo.xml
@@ -24,21 +24,130 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.2.39" date="2023-10-25"/>
+    <release version="1.2.39" date="2023-10-25">
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1239</url>
+    </release>
     <release version="1.2.38" date="2023-09-23"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1238</url>
+    </release>
     <release version="1.2.37" date="2023-09-20"/>
+      <description>
+        <ul>
+          <li>Security update for Electron (fix for CVE-2023-4863)</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1237</url>
+    </release>
     <release version="1.2.36" date="2023-08-31"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1236</url>
+    </release>
     <release version="1.2.35" date="2023-08-21"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1235</url>
+    </release>
     <release version="1.2.31" date="2023-06-01"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1231</url>
+    </release>
     <release version="1.2.29" date="2023-03-15"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1229</url>
+    </release>
     <release version="1.2.27" date="2022-12-14"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1227</url>
+    </release>
     <release version="1.2.25" date="2022-12-06"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1225</url>
+    </release>
     <release version="1.2.21" date="2022-09-14"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1221</url>
+    </release>
     <release version="1.2.18" date="2022-07-21"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1218</url>
+    </release>
     <release version="1.2.13" date="2022-06-07"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_1213</url>
+    </release>
     <release version="1.2.7" date="2022-04-26"/>
+      <description>
+        <ul>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_127</url>
+    </release>
     <release version="1.2.5" date="2022-04-20"/>
+      <description>
+        <ul>
+          <li>macOS: File attributes are set correctly on downloaded files</li>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_125</url>
+    </release>
     <release version="1.2.0" date="2022-04-04"/>
+      <description>
+        <ul>
+          <li>macOS: Improved support for Apple processors</li>
+          <li>Linux: Fixed an issue where the app icon was missing in some cases</li>
+          <li>Linux: The rpm package is now signed (<url>https://threema.ch/en/faq/rpm_signature</url>)</li>
+          <li>Miscellaneous minor improvements and bug fixes</li>
+        </ul>
+      </description>
+      <url>https://threema.ch/en/whats-new#web_desktop_120</url>
+    </release>
     <release version="1.1.0" date="2021-12-15"/>
     <release version="1.0.3" date="2021-10-26"/>
   </releases>


### PR DESCRIPTION
This allows AppStream consumers (GNOME Software, flathub.org, ...) to advertise the release notes: 
![image](https://github.com/threema-ch/threema-web-electron/assets/7831843/9d350246-cb06-4b2d-beb4-113d52eddb3b)
